### PR TITLE
Android/refactor/#181

### DIFF
--- a/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
+++ b/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
@@ -631,9 +631,6 @@ class OnboardingActivity:ComponentActivity() {
                     if(navController.currentDestination?.route == OnboardingScreen.FindPassword.name){
                         navController.navigate(OnboardingScreen.FindPasswordNumber.name)
                     }
-
-                    Toast.makeText(this@OnboardingActivity,"인증번호를 보냈습니다.",Toast.LENGTH_SHORT).show()
-
                 }
             }else{
                 BigButton("다음", false) { navController.navigate(OnboardingScreen.SignupNumber.name) }            }
@@ -1173,8 +1170,6 @@ class OnboardingActivity:ComponentActivity() {
                     if(navController.currentDestination?.route == OnboardingScreen.FindPassword.name){
                         navController.navigate(OnboardingScreen.FindPasswordNumber.name)
                     }
-
-                    Toast.makeText(this@OnboardingActivity,"인증번호를 보냈습니다.",Toast.LENGTH_SHORT).show()
                 }
             }else{
                 BigButton("다음", false) { navController.navigate(OnboardingScreen.FindPasswordNumber.name) }            }

--- a/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
+++ b/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
@@ -755,6 +755,19 @@ class OnboardingActivity:ComponentActivity() {
         val focusRequester = remember { FocusRequester() }
         val focusManager = LocalFocusManager.current
         authCode.value = number.value
+        val topshowBubble = remember {mutableStateOf(true)}
+        val bottomshowBubble = remember {mutableStateOf(false)}
+
+        LaunchedEffect(Unit) {
+            delay(5000) // 5초 동안 말풍선 표시
+            topshowBubble.value = false
+        }
+        if (bottomshowBubble.value){
+            LaunchedEffect(Unit) {
+                delay(2000) // 2초 동안 말풍선 표시
+                bottomshowBubble.value = false
+            }
+        }
 
         LaunchedEffect(Unit) {
             focusRequester.requestFocus()
@@ -784,22 +797,11 @@ class OnboardingActivity:ComponentActivity() {
             Column(modifier = Modifier.fillMaxHeight(),
                 verticalArrangement = Arrangement.Center) {
                 Column(modifier = Modifier
+                    .height(42.dp)
                     .padding(horizontal = 24.dp)) {
-                    Box(
-                        contentAlignment = Alignment.TopCenter
-                    ){
-                        Spacer(modifier = Modifier.width(18.dp))
-                        Image(
-                            modifier = Modifier
-                                .width(205.dp)
-                                .height(42.dp),
-                            painter = painterResource(id = R.drawable.img_alarm_grey), contentDescription = ""
-                        )
-                        Column(modifier = Modifier
-                            .padding(top = 5.dp)) {
-                            P_Medium11(content = "입력하신 이메일로 인증번호가 전송되었어요\n" +
-                                    "메일함을 확인해 주세요", color = white)
-                        }
+                    if (topshowBubble.value) {
+                        val toptext = "입력하신 이메일로 인증번호가 전송되었어요\n" + "메일함을 확인해 주세요"
+                        TopSpeechBubble(toptext)
                     }
                 }
 
@@ -860,6 +862,7 @@ class OnboardingActivity:ComponentActivity() {
                                     isSignUp = "false"
                                 )
                             )
+                            bottomshowBubble.value = true
                         }){
                         Column {
                             Column(modifier = Modifier
@@ -874,22 +877,12 @@ class OnboardingActivity:ComponentActivity() {
                         }
                     }
                     Row(modifier = Modifier
+                        .height(26.dp)
                         .padding(horizontal = 8.dp)
                         .align(Alignment.End)){
-                        Box(
-                            contentAlignment = Alignment.BottomCenter
-                        ){
-                            Spacer(modifier = Modifier.width(18.dp))
-                            Image(
-                                modifier = Modifier
-                                    .width(155.dp)
-                                    .height(26.dp),
-                                painter = painterResource(id = R.drawable.img_alarmup_grey), contentDescription = ""
-                            )
-                            Column(modifier = Modifier
-                                .padding(bottom = 5.dp)) {
-                                P_Medium11(content = "동일한 이메일로 재전송되었어요", color = white)
-                            }
+                        if (bottomshowBubble.value){
+                            val bottomtext = "동일한 이메일로 재전송되었어요"
+                            BottomSpeechBubble(text = bottomtext)
                         }
                     }
                 }

--- a/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
+++ b/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
@@ -98,6 +98,7 @@ import com.google.android.gms.tasks.OnCompleteListener
 import com.google.android.gms.tasks.Task
 import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 enum class OnboardingScreen(){
@@ -392,8 +393,8 @@ class OnboardingActivity:ComponentActivity() {
                     Column(modifier = Modifier
                         .width(76.dp)
                         .clickable {
-//                            navController.navigate(OnboardingScreen.FindPassword.name)
-                            Toast.makeText(this@OnboardingActivity,"서버오류",Toast.LENGTH_SHORT).show()
+                            navController.navigate(OnboardingScreen.FindPassword.name)
+                            //Toast.makeText(this@OnboardingActivity,"서버오류",Toast.LENGTH_SHORT).show()
                         }) {
                         Column(modifier = Modifier
                             .padding(horizontal = 8.dp)) {
@@ -1194,6 +1195,21 @@ class OnboardingActivity:ComponentActivity() {
         LaunchedEffect(Unit) {
             focusRequester.requestFocus()
         }
+
+        val topshowBubble = remember {mutableStateOf(true)}
+        val bottomshowBubble = remember {mutableStateOf(false)}
+
+        LaunchedEffect(Unit) {
+            delay(5000) // 5초 동안 말풍선 표시
+            topshowBubble.value = false
+        }
+        if (bottomshowBubble.value){
+            LaunchedEffect(Unit) {
+                delay(2000) // 2초 동안 말풍선 표시
+                bottomshowBubble.value = false
+            }
+        }
+
         Box(modifier = Modifier
             .fillMaxSize()
             .background(color = tertiary_500)
@@ -1212,20 +1228,12 @@ class OnboardingActivity:ComponentActivity() {
             Column(modifier = Modifier.fillMaxHeight(),
                 verticalArrangement = Arrangement.Center) {
                 Column(modifier = Modifier
+                    .height(42.dp)
                     .padding(horizontal = 24.dp)) {
-                    Box(
-                        contentAlignment = Alignment.Center
-                    ){
-                        Spacer(modifier = Modifier.width(18.dp))
-                        Image(
-                            modifier = Modifier
-                                .width(205.dp)
-                                .height(42.dp),
-                            painter = painterResource(id = R.drawable.img_alarm_grey), contentDescription = ""
-                        )
-                        P_Medium11(content = "입력하신 이메일로 복구코드가 전송되었어요\n" +
-                                "메일함을 확인해 주세요", color = white
-                        )
+
+                    if (topshowBubble.value) {
+                        val toptext = "입력하신 이메일로 인증번호가 전송되었어요\n" + "메일함을 확인해 주세요"
+                        TopSpeechBubble(toptext)
                     }
                 }
 
@@ -1281,6 +1289,7 @@ class OnboardingActivity:ComponentActivity() {
                                     isSignUp = "false"
                                 )
                             )
+                            bottomshowBubble.value = true
                         }) {
                         Column {
                             Column(modifier = Modifier
@@ -1295,23 +1304,14 @@ class OnboardingActivity:ComponentActivity() {
                         }
                     }
                     Row(modifier = Modifier
+                        .height(26.dp)
                         .padding(horizontal = 8.dp)
                         .align(Alignment.End)
 
                 ) {
-
-                        Box(
-                            contentAlignment = Alignment.Center
-                        ){
-                            Spacer(modifier = Modifier.width(18.dp))
-                            Image(
-                                modifier = Modifier
-                                    .width(155.dp)
-                                    .height(26.dp),
-                                painter = painterResource(id = R.drawable.img_alarmup_grey), contentDescription = ""
-                            )
-
-                            P_Medium11(content = "동일한 이메일로 재전송되었어요", color = white)
+                        if (bottomshowBubble.value){
+                            val bottomtext = "동일한 이메일로 재전송되었어요"
+                            BottomSpeechBubble(text = bottomtext)
                         }
                     }
                 }

--- a/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
+++ b/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
@@ -10,6 +10,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.Image
@@ -757,6 +758,12 @@ class OnboardingActivity:ComponentActivity() {
     @Composable
     fun SignupNumber(countViewModel: CountViewModel = viewModel(), authCode:MutableState<String>,
                      email : MutableState<String>){
+        BackHandler {
+            navController.navigate(OnboardingScreen.SignupEmail.name, navOptions {
+                popUpTo(OnboardingScreen.SignupEmail.name) { inclusive = true }
+                launchSingleTop = true
+            })
+        }
 
         val timeLeft by countViewModel.timeLeft.collectAsState()
         val number = remember{mutableStateOf("")}
@@ -924,6 +931,13 @@ class OnboardingActivity:ComponentActivity() {
 
     @Composable
     fun Signup(emailAuthCode:MutableState<String>, email : MutableState<String>){
+
+        BackHandler {
+            navController.navigate(OnboardingScreen.SignupNumber.name, navOptions {
+                popUpTo(OnboardingScreen.SignupNumber.name) { inclusive = true }
+                launchSingleTop = true
+            })
+        }
         val password = remember{
             mutableStateOf("")
         }
@@ -1061,6 +1075,14 @@ class OnboardingActivity:ComponentActivity() {
 
     @Composable
     fun SignupComplete(){
+
+        BackHandler {
+            navController.navigate(OnboardingScreen.Login.name, navOptions {
+                popUpTo(0) { inclusive = true }
+                launchSingleTop = true
+            })
+        }
+
         Box(modifier = Modifier
             .fillMaxSize()
             .background(color = tertiary_500)
@@ -1194,6 +1216,13 @@ class OnboardingActivity:ComponentActivity() {
     // 비밀번호 찾기에서 인증코드 확인
     @Composable
     fun FindPasswordNumber(authCode:MutableState<String>, id: MutableState<String>){
+
+        BackHandler {
+            navController.navigate(OnboardingScreen.FindPassword.name, navOptions {
+                popUpTo(OnboardingScreen.FindPassword.name) { inclusive = true }
+                launchSingleTop = true
+            })
+        }
 
         val findpwnumState = remember{
             mutableStateOf(true)
@@ -1350,6 +1379,13 @@ class OnboardingActivity:ComponentActivity() {
 
     @Composable
     fun  FindPasswordSignup(code:String) {
+
+        BackHandler {
+            navController.navigate(OnboardingScreen.FindPasswordNumber.name, navOptions {
+                popUpTo(OnboardingScreen.FindPasswordNumber.name) { inclusive = true }
+                launchSingleTop = true
+            })
+        }
 
         val password = remember {
             mutableStateOf("")

--- a/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
+++ b/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
@@ -786,7 +786,7 @@ class OnboardingActivity:ComponentActivity() {
                 Column(modifier = Modifier
                     .padding(horizontal = 24.dp)) {
                     Box(
-                        contentAlignment = Alignment.Center
+                        contentAlignment = Alignment.TopCenter
                     ){
                         Spacer(modifier = Modifier.width(18.dp))
                         Image(
@@ -795,8 +795,11 @@ class OnboardingActivity:ComponentActivity() {
                                 .height(42.dp),
                             painter = painterResource(id = R.drawable.img_alarm_grey), contentDescription = ""
                         )
-                        P_Medium11(content = "입력하신 이메일로 인증번호가 전송되었어요\n" +
-                                "메일함을 확인해 주세요", color = white)
+                        Column(modifier = Modifier
+                            .padding(top = 5.dp)) {
+                            P_Medium11(content = "입력하신 이메일로 인증번호가 전송되었어요\n" +
+                                    "메일함을 확인해 주세요", color = white)
+                        }
                     }
                 }
 
@@ -874,7 +877,7 @@ class OnboardingActivity:ComponentActivity() {
                         .padding(horizontal = 8.dp)
                         .align(Alignment.End)){
                         Box(
-                            contentAlignment = Alignment.Center
+                            contentAlignment = Alignment.BottomCenter
                         ){
                             Spacer(modifier = Modifier.width(18.dp))
                             Image(
@@ -883,7 +886,10 @@ class OnboardingActivity:ComponentActivity() {
                                     .height(26.dp),
                                 painter = painterResource(id = R.drawable.img_alarmup_grey), contentDescription = ""
                             )
-                            P_Medium11(content = "동일한 이메일로 재전송되었어요", color = white)
+                            Column(modifier = Modifier
+                                .padding(bottom = 5.dp)) {
+                                P_Medium11(content = "동일한 이메일로 재전송되었어요", color = white)
+                            }
                         }
                     }
                 }
@@ -1501,6 +1507,11 @@ class OnboardingActivity:ComponentActivity() {
     @Preview
     @Composable
     fun OnboardingPreView(){
-        Login()
+        val authCodeInSignup = remember {
+            mutableStateOf("")
+        }
+
+        val email = remember{mutableStateOf("")}
+        SignupNumber(authCode=authCodeInSignup, email = email)
     }
 }

--- a/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
+++ b/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
@@ -639,10 +639,6 @@ class OnboardingActivity:ComponentActivity() {
                     if(navController.currentDestination?.route == OnboardingScreen.SignupEmail.name){
                         navController.navigate(OnboardingScreen.SignupNumber.name)
                     }
-
-                    if(navController.currentDestination?.route == OnboardingScreen.FindPassword.name){
-                        navController.navigate(OnboardingScreen.FindPasswordNumber.name)
-                    }
                 }
             }else{
                 BigButton("다음", false) { navController.navigate(OnboardingScreen.SignupNumber.name) }            }
@@ -1205,9 +1201,6 @@ class OnboardingActivity:ComponentActivity() {
                             isSignUp = "false"
                         )
                     )
-                    if(navController.currentDestination?.route == OnboardingScreen.SignupEmail.name){
-                        navController.navigate(OnboardingScreen.SignupNumber.name)
-                    }
 
                     if(navController.currentDestination?.route == OnboardingScreen.FindPassword.name){
                         navController.navigate(OnboardingScreen.FindPasswordNumber.name)
@@ -1376,7 +1369,7 @@ class OnboardingActivity:ComponentActivity() {
                                 code = authCode.value
                             )
                         )
-                        navController.navigate(OnboardingScreen.FindPasswordSignup.name)
+                        //navController.navigate(OnboardingScreen.FindPasswordSignup.name)
                     }
                 }else{
                     BigButton("다음", false) { navController.navigate(OnboardingScreen.FindPasswordSignup.name) }

--- a/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
+++ b/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
@@ -1502,6 +1502,43 @@ class OnboardingActivity:ComponentActivity() {
     }*/
 
 
+    @Composable
+    fun TopSpeechBubble(text : String){
+        Box(
+            contentAlignment = Alignment.TopCenter
+        ){
+            Spacer(modifier = Modifier.width(18.dp))
+            Image(
+                modifier = Modifier
+                    .width(205.dp)
+                    .height(42.dp),
+                painter = painterResource(id = R.drawable.img_alarm_grey), contentDescription = ""
+            )
+            Column(modifier = Modifier
+                .padding(top = 5.dp)) {
+                P_Medium11(content = text, color = white)
+            }
+        }
+    }
+
+    @Composable
+    fun BottomSpeechBubble(text : String){
+        Box(
+            contentAlignment = Alignment.BottomCenter
+        ){
+            Spacer(modifier = Modifier.width(18.dp))
+            Image(
+                modifier = Modifier
+                    .width(155.dp)
+                    .height(26.dp),
+                painter = painterResource(id = R.drawable.img_alarmup_grey), contentDescription = ""
+            )
+            Column(modifier = Modifier
+                .padding(bottom = 5.dp)) {
+                P_Medium11(content = text, color = white)
+            }
+        }
+    }
 
 
     @Preview

--- a/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
+++ b/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
@@ -257,9 +257,9 @@ class OnboardingActivity:ComponentActivity() {
                 navController.navigate(OnboardingScreen.Signup.name)
             }
 
-            if(navController.currentDestination?.route == OnboardingScreen.FindPassword.name){
-                navController.navigate(OnboardingScreen.Login.name, navOptions {
-                    popUpTo(0) { inclusive = true }
+            if(navController.currentDestination?.route == OnboardingScreen.FindPasswordNumber.name){
+                navController.navigate(OnboardingScreen.FindPasswordSignup.name, navOptions {
+                    popUpTo(OnboardingScreen.FindPasswordSignup.name) { inclusive = true }
                     launchSingleTop = true
                 })
             }
@@ -806,7 +806,10 @@ class OnboardingActivity:ComponentActivity() {
                     .wrapContentSize()
             ) {
                 ImgBackButton(onClick = {
-                    navController.navigate(OnboardingScreen.SignupEmail.name)
+                    navController.navigate(OnboardingScreen.SignupEmail.name, navOptions {
+                        popUpTo(OnboardingScreen.SignupEmail.name) { inclusive = true }
+                        launchSingleTop = true
+                    })
                 }, "회원가입")
             }
 
@@ -967,7 +970,10 @@ class OnboardingActivity:ComponentActivity() {
                     .wrapContentSize()
             ) {
                 ImgBackButton(onClick = {
-                    navController.navigate(OnboardingScreen.SignupNumber.name)
+                    navController.navigate(OnboardingScreen.SignupNumber.name, navOptions {
+                        popUpTo(OnboardingScreen.SignupNumber.name) { inclusive = true }
+                        launchSingleTop = true
+                    })
                 }, "회원가입")
             }
 
@@ -1259,7 +1265,10 @@ class OnboardingActivity:ComponentActivity() {
                     .wrapContentSize()
             ) {
                 ImgBackButton(onClick = {
-                    navController.navigate(OnboardingScreen.SignupEmail.name)
+                    navController.navigate(OnboardingScreen.FindPassword.name, navOptions {
+                        popUpTo(OnboardingScreen.FindPassword.name) { inclusive = true }
+                        launchSingleTop = true
+                    })
                 }, "비밀번호 찾기")
             }
 
@@ -1415,7 +1424,10 @@ class OnboardingActivity:ComponentActivity() {
                     .wrapContentSize()
             ) {
                 ImgBackButton(onClick = {
-                    navController.navigate(OnboardingScreen.SignupNumber.name)
+                    navController.navigate(OnboardingScreen.FindPasswordNumber.name, navOptions {
+                        popUpTo(OnboardingScreen.FindPasswordNumber.name) { inclusive = true }
+                        launchSingleTop = true
+                    })
                 }, "비밀번호 찾기")
             }
 

--- a/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
+++ b/Android/moment-android/app/src/main/java/com/capstone/android/application/ui/OnboardingActivity.kt
@@ -64,6 +64,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navOptions
 import com.capstone.android.application.MainActivity
 import com.capstone.android.application.R
 import com.capstone.android.application.app.ApplicationClass.Companion.tokenSharedPreferences
@@ -256,7 +257,10 @@ class OnboardingActivity:ComponentActivity() {
             }
 
             if(navController.currentDestination?.route == OnboardingScreen.FindPassword.name){
-                navController.navigate(OnboardingScreen.Login.name)
+                navController.navigate(OnboardingScreen.Login.name, navOptions {
+                    popUpTo(0) { inclusive = true }
+                    launchSingleTop = true
+                })
             }
         }
 
@@ -270,7 +274,11 @@ class OnboardingActivity:ComponentActivity() {
         authViewModel.patchAuthChangePasswordSuccess.observe(this@OnboardingActivity){ response->
             Log.d("patchAuthChangePasswordSuccess", "initApi: ${navController.currentDestination?.route}")
             if(navController.currentDestination?.route == OnboardingScreen.FindPasswordSignup.name){
-                navController.navigate(OnboardingScreen.Login.name)
+                navController.navigate(OnboardingScreen.Login.name, navOptions {
+                    popUpTo(0) { inclusive = true }
+                    launchSingleTop = true
+                })
+
             }
             if(navController.currentDestination?.route == OnboardingScreen.Signup.name){
                 navController.navigate(OnboardingScreen.SignupComplete.name)
@@ -536,7 +544,10 @@ class OnboardingActivity:ComponentActivity() {
                     .wrapContentSize()
             ) {
                 ImgBackButton(onClick = {
-                    navController.navigate(OnboardingScreen.Login.name)
+                    navController.navigate(OnboardingScreen.Login.name, navOptions {
+                        popUpTo(0) { inclusive = true }
+                        launchSingleTop = true
+                    })
                 }, "회원가입")
             }
 
@@ -1104,7 +1115,10 @@ class OnboardingActivity:ComponentActivity() {
                     .wrapContentSize()
             ) {
                 ImgBackButton(onClick = {
-                    navController.navigate(OnboardingScreen.Login.name)
+                    navController.navigate(OnboardingScreen.Login.name, navOptions {
+                        popUpTo(0) { inclusive = true }
+                        launchSingleTop = true
+                    })
                 }, "비밀번호 찾기")
             }
 


### PR DESCRIPTION
회원가입 & 비밀번호 찾기
- 인증번호 및 복구번호 화면 말풍선 ui 수정
- 인증번호 및 복구번호 화면 입장시, 말풍선 일시적 뜨도록 적용
- 인증번호 및 복구번호 화면에서 재전송 버튼 누를시, 말풍선 일시적 뜨도록 적용
- 비밀번호 찾기 화면 이동 오류 해결
- 회원가입, 비밀번호 찾기  화면 BackHandler 적용


